### PR TITLE
Adds conditional generation to the trainer module as a command-line argument

### DIFF
--- a/unet.py
+++ b/unet.py
@@ -54,9 +54,8 @@ class UNet(nn.Module):
         return condlayer(x, c)
 
     def forward(self, x, t, c=None, puncond=0.1):
-        if c is not None:
-            condition_toggle = False if random.uniform(0,1) < puncond else True # Discards the condition with probability puncond
-            x = self.apply_condition(x, c, condition_toggle, 1) # TODO: add this to a few other places in this method. Make sure to change the key every time
+        condition_toggle = False if (random.uniform(0,1) < puncond or c is None) else True # Discards the condition with probability puncond 
+        x = self.apply_condition(x, c, condition_toggle, 1) # TODO: add this to a few other places in this method. Make sure to change the key every time
 
         t = t.unsqueeze(-1).type(torch.float)
         t = self.pos_encoding(t, self.time_dim)


### PR DESCRIPTION
`unet.py`
- Fixes dimension issues that consider the batch size by changing Linear layer input and output dimensions
- Use Torch reshape instead of a Sequential View layer
- Modifies logic so Conditional Layer can be added anywhere in the UNet architecture

`trainer.py`
- Adds conditional generation capability via a command-line argument `--conditional` that is defaulted to False
- By default, conditional generation is turned off and does not impact logic of non-conditional generation
